### PR TITLE
Added variant support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.spigotmc:spigot-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.21.10-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.fasterxml.jackson.core:jackson-core:2.18.3")
     compileOnly("com.fasterxml.jackson.core:jackson-databind:2.18.3")

--- a/src/main/java/me/xemor/configurationdata/entity/EntityComponentRegistry.java
+++ b/src/main/java/me/xemor/configurationdata/entity/EntityComponentRegistry.java
@@ -14,14 +14,22 @@ public class EntityComponentRegistry {
     static {
         registerEntityData(Arrow.class, ArrowComponent.class);
         registerEntityData(Axolotl.class, AxolotlComponent.class);
+        registerEntityData(Cat.class, VariantComponent.class);
+        registerEntityData(Chicken.class, VariantComponent.class);
+        registerEntityData(Cow.class, VariantComponent.class);
         registerEntityData(Creeper.class, CreeperComponent.class);
         registerEntityData(Item.class, DroppedItemComponent.class);
         registerEntityData(ExperienceOrb.class, ExperienceOrbComponent.class);
         registerEntityData(FallingBlock.class, FallingBlockComponent.class);
+        registerEntityData(Fox.class, VariantComponent.class);
+        registerEntityData(Frog.class, VariantComponent.class);
         registerEntityData(AbstractHorse.class, AbstractHorseComponent.class);
         registerEntityData(Horse.class, HorseComponent.class);
         registerEntityData(ChestedHorse.class, ChestedHorseComponent.class);
         registerEntityData(Llama.class, LlamaComponent.class);
+        registerEntityData(MushroomCow.class, VariantComponent.class);
+        registerEntityData(Parrot.class, VariantComponent.class);
+        registerEntityData(Pig.class, VariantComponent.class);
         registerEntityData(TNTPrimed.class, PrimedTntComponent.class);
         registerEntityData(SpectralArrow.class, SpectralArrowComponent.class);
         registerEntityData(ThrownPotion.class, PotionEntityComponent.class);
@@ -32,12 +40,14 @@ public class EntityComponentRegistry {
         registerEntityData(Ageable.class, AgeableComponent.class);
         registerEntityData(Colorable.class, ColorableComponent.class);
         registerEntityData(Explosive.class, ExplosiveComponent.class);
+        registerEntityData(Salmon.class, VariantComponent.class);
         registerEntityData(Slime.class, SizeComponent.class);
         registerEntityData(Phantom.class, SizeComponent.class);
         registerEntityData(ThrowableProjectile.class, ThrowableProjectileComponent.class);
         registerEntityData(PiglinAbstract.class, ZombifiableComponent.class);
         registerEntityData(Hoglin.class, ZombifiableComponent.class);
         registerEntityData(LivingEntity.class, LivingEntityComponent.class);
+        registerEntityData(Villager.class, VariantComponent.class);
     }
 
     public static void registerEntityData(Class inheritsFrom, Class<? extends EntityComponent> entityComponentDataClass) {

--- a/src/main/java/me/xemor/configurationdata/entity/WolfComponent.java
+++ b/src/main/java/me/xemor/configurationdata/entity/WolfComponent.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Wolf;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WolfComponent implements EntityComponent {
 
+    // TODO: Add variant
     @JsonPropertyWithDefault
     private boolean angry = false;
 

--- a/src/main/java/me/xemor/configurationdata/entity/components/VariantComponent.java
+++ b/src/main/java/me/xemor/configurationdata/entity/components/VariantComponent.java
@@ -1,0 +1,52 @@
+package me.xemor.configurationdata.entity.components;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import me.xemor.configurationdata.JsonPropertyWithDefault;
+import me.xemor.configurationdata.entity.EntityData;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.entity.*;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VariantComponent implements EntityComponent {
+
+    @JsonPropertyWithDefault
+    private String variant = null;
+
+    @Override
+    public void apply(Entity entity, EntityData builderSoFar) {
+        if (entity instanceof Cat cat) {
+            cat.setCatType(Registry.CAT_VARIANT.getOrThrow(NamespacedKey.fromString(variant)));
+        }
+        else if (entity instanceof Chicken chicken) {
+            chicken.setVariant(Registry.CHICKEN_VARIANT.getOrThrow(NamespacedKey.fromString(variant)));
+        }
+        else if (entity instanceof Cow cow) {
+            cow.setVariant(Registry.COW_VARIANT.getOrThrow(NamespacedKey.fromString(variant)));
+        }
+        else if (entity instanceof Fox fox) {
+            fox.setFoxType(Fox.Type.valueOf(variant));
+        }
+        else if (entity instanceof Frog frog) {
+            frog.setVariant(Registry.FROG_VARIANT.getOrThrow(NamespacedKey.fromString(variant)));
+        }
+        else if (entity instanceof MushroomCow mushroomCow) {
+            mushroomCow.setVariant(MushroomCow.Variant.valueOf(variant));
+        }
+        else if (entity instanceof Parrot parrot) {
+            parrot.setVariant(Parrot.Variant.valueOf(variant));
+        }
+        else if (entity instanceof Pig pig) {
+            pig.setVariant(Registry.PIG_VARIANT.getOrThrow(NamespacedKey.fromString(variant)));
+        }
+        else if (entity instanceof Salmon salmon) {
+            salmon.setVariant(Salmon.Variant.valueOf(variant));
+        }
+        else if (entity instanceof Villager villager) {
+            villager.setVillagerType(Registry.VILLAGER_TYPE.getOrThrow(NamespacedKey.fromString(variant)));
+        }
+        else if (entity instanceof Wolf wolf) {
+            wolf.setVariant(Registry.WOLF_VARIANT.getOrThrow(NamespacedKey.fromString(variant)));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds variants for the majority of entity types. Ideally many of these would be migrated to the specific entity components, but not sure how that would need to be done jackson wise, so I opted for this solution.